### PR TITLE
[Feature]수강신청 페이지 구현_425

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### resource ###
 ./src/main/resources/application.properties
+./src/main/java/com/example/modoosugang_be/MailConfig.java

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### resource ###
+./src/main/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'mysql:mysql-connector-java'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/example/modoosugang_be/Controller/MailController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/MailController.java
@@ -24,7 +24,10 @@ public class MailController {
     private final ProfessorService professorService;
     private final RequestingService requestingService;
 
-    @Scheduled(fixedDelay = 10000)
+//    10초에 한번씩 실행
+//    @Scheduled(fixedDelay = 10000)
+//    매일 자정에 실행
+    @Scheduled(cron = "0 0 0 * * *")
     public void handleRequesting(){
         List<Professor> professorList = professorService.callProfessorList();
 

--- a/src/main/java/com/example/modoosugang_be/Controller/MailController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/MailController.java
@@ -1,32 +1,67 @@
 package com.example.modoosugang_be.Controller;
 
+
+import com.example.modoosugang_be.Domain.EmailMessage;
+import com.example.modoosugang_be.Domain.Professor;
+import com.example.modoosugang_be.Domain.Request;
+import com.example.modoosugang_be.Service.MailService;
+import com.example.modoosugang_be.Service.ProfessorService;
+import com.example.modoosugang_be.Service.RequestingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import javax.mail.internet.MimeMessage;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
 
 @Component
 @RequiredArgsConstructor
-public class MailController implements ApplicationRunner {
-    private final JavaMailSender mailSender;
+public class MailController {
 
-    @Value("${spring.mail.username}")
-    private String from;
+    private final MailService emailService;
+    private final ProfessorService professorService;
+    private final RequestingService requestingService;
 
-    @Override
-    public void run(ApplicationArguments args) throws Exception {
+    @Scheduled(fixedDelay = 10000)
+    public void handleRequesting(){
+        List<Professor> professorList = professorService.callProfessorList();
 
-//        MimeMessage m = mailSender.createMimeMessage();
-//        MimeMessageHelper h = new MimeMessageHelper(m,"UTF-8");
-//        h.setFrom("");
-//        h.setTo("");
-//        h.setSubject("테스트메일");
-//        h.setText("메일테스트");
-//        mailSender.send(m);
+        for (Professor professor : professorList) {
+            System.out.println(professor.getId());
+            List<Request> requests = requestingService.callRequestByProfessor(professor.getId());
+            Map<String, int[]> requestCounter = new HashMap<>();
+
+            for (Request request : requests) {
+                System.out.println(request.getLecture());
+                int[] prevVal = requestCounter.get(request.getLecture());
+                if (prevVal == null) {
+                    requestCounter.put(request.getLecture(), new int[]{1});
+                } else {
+                    prevVal[0]++;
+                }
+            }
+
+            String EmailContext = "다음과 같은 증원 신청 요청이 있습니다.\n";
+            for (String key : requestCounter.keySet()) {
+                EmailContext = EmailContext + key+": "+requestCounter.get(key)[0] + "명\n";
+            }
+            System.out.println("Email: "+professor.getEmail());
+            System.out.println("Content: "+EmailContext);
+            sendMail(professor.getEmail(), EmailContext);
+        }
+    }
+
+
+
+    public void sendMail(String email, String contents) {
+        EmailMessage emailMessage = EmailMessage.builder()
+                .to(email)
+                .subject("[ModooSugang] 증원 신청 요청")
+                .message(contents)
+                .build();
+        emailService.sendMail(emailMessage);
+        System.out.println("Send~~");
     }
 }

--- a/src/main/java/com/example/modoosugang_be/Controller/MailController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/MailController.java
@@ -28,29 +28,35 @@ public class MailController {
     public void handleRequesting(){
         List<Professor> professorList = professorService.callProfessorList();
 
-        for (Professor professor : professorList) {
-            System.out.println(professor.getId());
-            List<Request> requests = requestingService.callRequestByProfessor(professor.getId());
-            Map<String, int[]> requestCounter = new HashMap<>();
+        if (professorList.size() > 0) {
+            for (Professor professor : professorList) {
+                System.out.println(professor.getId());
+                List<Request> requests = requestingService.callRequestByProfessor(professor.getId());
 
-            for (Request request : requests) {
-                System.out.println(request.getLecture());
-                int[] prevVal = requestCounter.get(request.getLecture());
-                if (prevVal == null) {
-                    requestCounter.put(request.getLecture(), new int[]{1});
-                } else {
-                    prevVal[0]++;
+                if (requests.size() > 0) {
+                    Map<String, int[]> requestCounter = new HashMap<>();
+
+                    for (Request request : requests) {
+                        System.out.println(request.getLecture());
+                        int[] prevVal = requestCounter.get(request.getLecture());
+                        if (prevVal == null) {
+                            requestCounter.put(request.getLecture(), new int[]{1});
+                        } else {
+                            prevVal[0]++;
+                        }
+                    }
+
+                    String EmailContext = "다음과 같은 증원 신청 요청이 있습니다.\n";
+                    for (String key : requestCounter.keySet()) {
+                        EmailContext = EmailContext + key+": "+requestCounter.get(key)[0] + "명\n";
+                    }
+                    System.out.println("Email: "+professor.getEmail());
+                    System.out.println("Content: "+EmailContext);
+                    sendMail(professor.getEmail(), EmailContext);
                 }
             }
-
-            String EmailContext = "다음과 같은 증원 신청 요청이 있습니다.\n";
-            for (String key : requestCounter.keySet()) {
-                EmailContext = EmailContext + key+": "+requestCounter.get(key)[0] + "명\n";
-            }
-            System.out.println("Email: "+professor.getEmail());
-            System.out.println("Content: "+EmailContext);
-            sendMail(professor.getEmail(), EmailContext);
         }
+
     }
 
 

--- a/src/main/java/com/example/modoosugang_be/Controller/MailController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/MailController.java
@@ -1,0 +1,32 @@
+package com.example.modoosugang_be.Controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import javax.mail.internet.MimeMessage;
+
+@Component
+@RequiredArgsConstructor
+public class MailController implements ApplicationRunner {
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String from;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+
+//        MimeMessage m = mailSender.createMimeMessage();
+//        MimeMessageHelper h = new MimeMessageHelper(m,"UTF-8");
+//        h.setFrom("");
+//        h.setTo("");
+//        h.setSubject("테스트메일");
+//        h.setText("메일테스트");
+//        mailSender.send(m);
+    }
+}

--- a/src/main/java/com/example/modoosugang_be/Controller/ManagerSearchController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/ManagerSearchController.java
@@ -3,7 +3,6 @@ package com.example.modoosugang_be.Controller;
 import com.example.modoosugang_be.Domain.StudentLog;
 import com.example.modoosugang_be.Service.StudentLogService;
 import lombok.RequiredArgsConstructor;
-import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/modoosugang_be/Controller/StudentBasketController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/StudentBasketController.java
@@ -1,0 +1,61 @@
+package com.example.modoosugang_be.Controller;
+
+import com.example.modoosugang_be.Domain.Lecture;
+import com.example.modoosugang_be.Domain.RegisterLecture;
+import com.example.modoosugang_be.Service.LectureService;
+import com.example.modoosugang_be.Service.RegisterBasketService;
+import com.example.modoosugang_be.Service.RegisterLectureService;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONObject;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping(value = "/api")
+@RequiredArgsConstructor
+public class StudentBasketController {
+
+    private final RegisterBasketService registerBasketService;
+    private final LectureService lectureService;
+//
+//    @PostMapping("/student/entroll/basket_list/'")
+//    public List BasketTable(@RequestBody Map<String, Object> param) {
+//        String student = param.get("id").toString();
+//
+//        List<RegisterLecture> baskets = registerBasketService.findBasketList(student);
+//        //List<Lecture> lectures
+//        List list = new ArrayList();
+//        for (RegisterLecture basket : baskets){
+//            JSONObject data = new JSONObject();
+//            // Create Json Array
+//            data.put("code", basket.getIdx());
+//            data.put("lecture", basket.getIdx());
+//            data.put("catrgory", basket.getIdx());
+//            data.put("time", basket.getIdx());
+//            data.put("professor", basket.getIdx());
+//            data.put("classroom", basket.getIdx());
+//            data.put("score", basket.getIdx());
+//
+//            list.add(data);
+//        }
+//        System.out.println("==================");
+//        System.out.println(list);
+//
+//
+//        return list;
+//
+//    }
+
+    // 장바구니 신청 구현할때 오픈
+//    @PostMapping("")
+//    public boolean Applybasket(@RequestBody Map<String, Object> param) {
+//
+//    }
+}

--- a/src/main/java/com/example/modoosugang_be/Controller/StudentEnrollController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/StudentEnrollController.java
@@ -1,0 +1,101 @@
+package com.example.modoosugang_be.Controller;
+
+import com.example.modoosugang_be.Domain.Lecture;
+import com.example.modoosugang_be.Domain.RegisterLecture;
+import com.example.modoosugang_be.Repository.RegisterLectureRepository;
+import com.example.modoosugang_be.Service.LectureService;
+import com.example.modoosugang_be.Service.RegisterLectureService;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.json.simple.JSONObject;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping(value = "/api")
+@RequiredArgsConstructor
+public class StudentEnrollController {
+
+    private final LectureService lectureService;
+    private final RegisterLectureService registerLectureService;
+
+    @PostMapping("/student/entroll/lecture_list")
+    public List LectureTable(@RequestBody Map<String, Object> param) {
+        String semester = param.get("semester").toString();
+        List<Lecture> logs = lectureService.findLectureList(semester);
+            List list = new ArrayList();
+            for (Lecture log : logs){
+                JSONObject data = new JSONObject();
+
+                // Create Json Array
+                data.put("index", log.getIdx());
+                data.put("name", log.getName());
+                data.put("major", log.getMajor());
+                data.put("classify", log.getClassify());
+                data.put("time", log.getTime());
+                data.put("classes", log.getClasses());
+                data.put("credit", log.getCredit());
+
+                String remain = String.valueOf(log.getRemain());
+                String limit = String.valueOf(log.getLimit());
+                String remaining = remain + "/" + limit;
+                data.put("remaining", remaining);
+
+                list.add(data);
+            }
+//        System.out.println("==================");
+//        System.out.println(list);
+
+        return list;
+    }
+
+    @PostMapping("/student/entroll/apply/lecture")
+    public boolean ApplyLecture(@RequestBody Map<String, Object> param) {
+        System.out.println((param)); //  {id=1, code=1010}
+
+//        String id = param.get("id").toString();
+//        String code = param.get("code").toString();
+//        String univ = param.get("univ").toString();
+//        String semester = param.get("semester").toString();
+
+        String semester ="2022_1";
+        String univ ="구름대학교";
+        int code = 1010;
+
+        // code 값으로 lecture 테이블 remain 잔여확인
+        Optional<Lecture> OptionalLecture = lectureService.findRemain((long) code);
+        int isRemain = OptionalLecture.get().getRemain();
+        System.out.println((isRemain));
+
+        String lecture_id = OptionalLecture.get().getId();
+        int schedule = 20220101; // 스케쥴 부분 타입 확인 필요
+        String student_id = "21611868"; // 일단 임의설정
+
+
+        if (isRemain > 0) {
+            int InputRemain = isRemain -1; // 잔여인원 차감
+            lectureService.setRemain((long) code, InputRemain); // 차감된 인원 DB update
+            // Register_lecture에 학생정보 적용
+            RegisterLecture regist = new RegisterLecture();
+
+            regist.setId(1L); // register_lecture_id : ??
+            regist.setIdx((long) code); // lecture_index : 강의code ?
+            regist.setLecture("BC1");
+            regist.setStudent(student_id);
+            regist.setSemester(semester);
+            regist.setSchedule("20220101");
+            regist.setUniv(univ);
+            registerLectureService.save(regist);
+
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+}
+

--- a/src/main/java/com/example/modoosugang_be/Controller/StudentMypageController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/StudentMypageController.java
@@ -28,7 +28,6 @@ public class StudentMypageController {
         List list = new ArrayList();
 
         for (RegisterLecture registerLecture : registerLectures) {
-            System.out.println(registerLecture.getLecture());
             Lecture lecture = lectureService.callLecutureByUnivAndId(univ, registerLecture.getLecture());
 
             JSONObject data = new JSONObject();

--- a/src/main/java/com/example/modoosugang_be/Controller/StudentMypageController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/StudentMypageController.java
@@ -1,0 +1,55 @@
+package com.example.modoosugang_be.Controller;
+
+import com.example.modoosugang_be.Domain.Lecture;
+import com.example.modoosugang_be.Domain.RegisterLecture;
+import com.example.modoosugang_be.Service.LectureService;
+import com.example.modoosugang_be.Service.RegisterLectureService;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONObject;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class StudentMypageController {
+
+    private final RegisterLectureService registerLectureService;
+    private final LectureService lectureService;
+
+    @PostMapping("/student/Mypage")
+    public List searchRegisterdLecture(@RequestBody Map<String, Object> param) {
+        String univ = param.get("univ").toString();
+        String id = univ + "@" + param.get("id").toString();
+        List<RegisterLecture> registerLectures = registerLectureService.findRegisterLecture(univ, id);
+        List list = new ArrayList();
+
+        for (RegisterLecture registerLecture : registerLectures) {
+            System.out.println(registerLecture.getLecture());
+            Lecture lecture = lectureService.callLecutureByUnivAndId(univ, registerLecture.getLecture());
+
+            JSONObject data = new JSONObject();
+
+            data.put("lecture_id", lecture.getId());
+            data.put("lecture_name", lecture.getName());
+            data.put("lecture_professor", lecture.getProname());
+            data.put("lecture_class", lecture.getClasses());
+            data.put("lecture_major", lecture.getMajor());
+            data.put("lecture_classify", lecture.getClassify());
+            data.put("lecture_time", lecture.getTime());
+            data.put("lecture_room", lecture.getRoom());
+            data.put("lecture_classroom", lecture.getClasses());
+            data.put("lecture_credit", lecture.getCredit());
+            data.put("lecture_first_sch", lecture.getFirstsch());
+            data.put("lecture_second_sch", lecture.getSecondsch());
+            data.put("lecture_idx", lecture.getIdx());
+
+            list.add(data);
+        }
+        return list;
+    }
+
+}

--- a/src/main/java/com/example/modoosugang_be/Controller/StudentSearchController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/StudentSearchController.java
@@ -17,7 +17,6 @@ public class StudentSearchController {
 
     @GetMapping("/student/class/{univ}")
     public List searchLectures(@PathVariable(name = "univ") String univ){
-
         List<Lecture> lectures = lectureService.callUnivLecture(univ);
         List list = new ArrayList();
 

--- a/src/main/java/com/example/modoosugang_be/Controller/StudentSearchController.java
+++ b/src/main/java/com/example/modoosugang_be/Controller/StudentSearchController.java
@@ -4,12 +4,10 @@ import com.example.modoosugang_be.Domain.Lecture;
 import com.example.modoosugang_be.Service.LectureService;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONObject;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -41,6 +39,7 @@ public class StudentSearchController {
             list.add(data);
         }
         System.out.println(list);
+
         return list;
     }
 }

--- a/src/main/java/com/example/modoosugang_be/Domain/EmailMessage.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/EmailMessage.java
@@ -1,0 +1,14 @@
+package com.example.modoosugang_be.Domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EmailMessage {
+    private String to;
+
+    private String subject;
+
+    private String message;
+}

--- a/src/main/java/com/example/modoosugang_be/Domain/Lecture.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/Lecture.java
@@ -8,6 +8,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.io.Serializable;
 import java.sql.Timestamp;
 
 @Getter
@@ -15,11 +16,11 @@ import java.sql.Timestamp;
 @RequiredArgsConstructor    // Constructor 주입 -> DI
 @Entity()                   // Connect table in DB
 @Table(name = "lecture")    // DB table name = "lecture"
-public class Lecture {
+public class Lecture implements Serializable {
 
     @Id
-    @Column(name = "lecture_idx")
-    private int idx;
+    @Column(name = "lecture_index")
+    private Long idx;
 
     @Column(name = "lecture_id")
     private String id;
@@ -51,4 +52,9 @@ public class Lecture {
     private String firstsch;
     @Column(name = "second_schedule")
     private String secondsch;
+    @Column(name = "lecture_remain")
+    private int remain;
+
+
+
 }

--- a/src/main/java/com/example/modoosugang_be/Domain/Lecture.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/Lecture.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Setter             // getter setter 자동생성
 @RequiredArgsConstructor    // Constructor 주입 -> DI
 @Entity()                   // Connect table in DB
-@Table(name = "lecture")    // DB table name = "student"
+@Table(name = "lecture")    // DB table name = "lecture"
 public class Lecture {
 
     @Id
@@ -47,4 +47,8 @@ public class Lecture {
     private String classify;
     @Column(name = "university_name")
     private String univ;
+    @Column(name = "first_schedule")
+    private String firstsch;
+    @Column(name = "second_schedule")
+    private String secondsch;
 }

--- a/src/main/java/com/example/modoosugang_be/Domain/Professor.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/Professor.java
@@ -1,0 +1,29 @@
+package com.example.modoosugang_be.Domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@Setter             // getter setter 자동생성
+@RequiredArgsConstructor    // Constructor 주입 -> DI
+@Entity()                   // Connect table in DB
+@Table(name = "professor")
+public class Professor {
+
+    @Id
+    @Column(name = "professor_id")
+    private String id;
+
+    @Column(name = "professor_name")
+    private String name;
+    @Column(name = "professor_major")
+    private String major;
+    @Column(name = "professor_email")
+    private String email;
+}

--- a/src/main/java/com/example/modoosugang_be/Domain/RegisterBasket.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/RegisterBasket.java
@@ -4,18 +4,21 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.io.Serializable;
 
 @Getter
 @Setter             // getter setter 자동생성
 @RequiredArgsConstructor    // Constructor 주입 -> DI
 @Entity()                   // Connect table in DB
-@Table(name = "register_lecture")    // DB table name = "register_lecture"
-public class RegisterLecture implements Serializable {
+@Table(name = "register_basket")    // DB table name = "register_lecture"
+public class RegisterBasket implements Serializable {
 
     @Id
-    @Column(name = "register_lecture_id")
+    @Column(name = "register_basket_id")
     private Long id;
 
     @Column(name = "lecture_index")
@@ -24,12 +27,8 @@ public class RegisterLecture implements Serializable {
     @Column(name = "student_id")
     private String student;
     @Column(name = "schedule_index")
-    private String schedule;
+    private int schedule;
     @Column(name = "univ_name")
     private String univ;
-    @Column(name = "lecture_id")
-    private String lecture;
-    @Column(name = "semester")
-    private String semester;
 
 }

--- a/src/main/java/com/example/modoosugang_be/Domain/RegisterLecture.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/RegisterLecture.java
@@ -1,0 +1,31 @@
+package com.example.modoosugang_be.Domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@Setter             // getter setter 자동생성
+@RequiredArgsConstructor    // Constructor 주입 -> DI
+@Entity()                   // Connect table in DB
+@Table(name = "register_lecture")    // DB table name = "register_lecture"
+public class RegisterLecture {
+
+    @Id
+    @Column(name = "register_lecture_id")
+    private int id;
+
+    @Column(name = "lecture_id")
+    private String lecture;
+    @Column(name = "student_id")
+    private String student;
+    @Column(name = "semester")
+    private String semester;
+    @Column(name = "univ_name")
+    private String univ;
+}

--- a/src/main/java/com/example/modoosugang_be/Domain/Request.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/Request.java
@@ -1,0 +1,27 @@
+package com.example.modoosugang_be.Domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@Setter             // getter setter 자동생성
+@RequiredArgsConstructor    // Constructor 주입 -> DI
+@Entity()                   // Connect table in DB
+@Table(name = "requesting")
+public class Request {
+
+    @Id
+    @Column(name = "requesting_id")
+    private int id;
+
+    @Column(name = "professor_id")
+    private String professor;
+    @Column(name = "lecture_id")
+    private String lecture;
+}

--- a/src/main/java/com/example/modoosugang_be/Domain/Schedule.java
+++ b/src/main/java/com/example/modoosugang_be/Domain/Schedule.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 public class Schedule implements Serializable {
 
     @Id
-    @Column(name = "id_schedule")
+    @Column(name = "schedule_index")
     private String Id;
 
     @Column(name = "semester")

--- a/src/main/java/com/example/modoosugang_be/MailConfig.java
+++ b/src/main/java/com/example/modoosugang_be/MailConfig.java
@@ -1,0 +1,28 @@
+package com.example.modoosugang_be;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Bean
+    public JavaMailSender getJavaMailSender(){
+        JavaMailSenderImpl mailSender=new JavaMailSenderImpl();
+
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername("modoosugang@gmail.com");
+        mailSender.setPassword("");
+
+        Properties props=mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol","smtp");
+        props.put("mail.smtp.auth","true");
+        props.put("mail.smtp.starttls.enable","true");
+//        props.put("mail.debug","true");
+        return mailSender;
+    }
+}

--- a/src/main/java/com/example/modoosugang_be/ModoosugangBeApplication.java
+++ b/src/main/java/com/example/modoosugang_be/ModoosugangBeApplication.java
@@ -2,7 +2,9 @@ package com.example.modoosugang_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ModoosugangBeApplication {
 

--- a/src/main/java/com/example/modoosugang_be/Repository/LectureRepository.java
+++ b/src/main/java/com/example/modoosugang_be/Repository/LectureRepository.java
@@ -2,16 +2,29 @@ package com.example.modoosugang_be.Repository;
 
 import com.example.modoosugang_be.Domain.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
     @Query(value = "SELECT v FROM Lecture v WHERE v.professor Like :univ%")
-    List<Lecture> findLecture(@Param("univ")String univ);
+    List<Lecture> findLecture(@Param("univ") String univ);
 
     @Query(value = "SELECT v FROM Lecture v WHERE v.professor Like :univ% AND v.id = :id")
     Lecture findLectureByUnivAndID(@Param("univ") String univ, @Param("id") String id);
+
+
+    List<Lecture> findAllBySemester(String semester);
+
+    List<Lecture> findAllByUniv(String univ);
+
+
+    @Transactional
+    @Modifying
+    @Query("update Lecture l set l.remain = :inputRemain where l.idx = :code")
+    int updateRemain(long code, int inputRemain);
 }

--- a/src/main/java/com/example/modoosugang_be/Repository/LectureRepository.java
+++ b/src/main/java/com/example/modoosugang_be/Repository/LectureRepository.java
@@ -8,10 +8,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
-    List<Lecture> findAllByProfessorContains(String professor);
-
-    List<Lecture> findAllByUniv(String univ);
 
     @Query(value = "SELECT v FROM Lecture v WHERE v.professor Like :univ%")
     List<Lecture> findLecture(@Param("univ")String univ);
+
+    @Query(value = "SELECT v FROM Lecture v WHERE v.professor Like :univ% AND v.id = :id")
+    Lecture findLectureByUnivAndID(@Param("univ") String univ, @Param("id") String id);
 }

--- a/src/main/java/com/example/modoosugang_be/Repository/ProfessorRepository.java
+++ b/src/main/java/com/example/modoosugang_be/Repository/ProfessorRepository.java
@@ -1,0 +1,10 @@
+package com.example.modoosugang_be.Repository;
+
+import com.example.modoosugang_be.Domain.Professor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProfessorRepository extends JpaRepository<Professor, Long> {
+    List<Professor> findAll();
+}

--- a/src/main/java/com/example/modoosugang_be/Repository/RegisterBasketRepository.java
+++ b/src/main/java/com/example/modoosugang_be/Repository/RegisterBasketRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface RegisterLectureRepository extends JpaRepository<RegisterLecture, Long> {
-    List<RegisterLecture> findAllByUnivAndStudent(String univ, String student);
+public interface RegisterBasketRepository extends JpaRepository<RegisterLecture, Long> {
 
 }

--- a/src/main/java/com/example/modoosugang_be/Repository/RegisterLectureRepository.java
+++ b/src/main/java/com/example/modoosugang_be/Repository/RegisterLectureRepository.java
@@ -1,0 +1,10 @@
+package com.example.modoosugang_be.Repository;
+
+import com.example.modoosugang_be.Domain.RegisterLecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RegisterLectureRepository extends JpaRepository<RegisterLecture, Long> {
+    List<RegisterLecture> findAllByUnivAndStudent(String univ, String student);
+}

--- a/src/main/java/com/example/modoosugang_be/Repository/RequestingRepository.java
+++ b/src/main/java/com/example/modoosugang_be/Repository/RequestingRepository.java
@@ -1,0 +1,10 @@
+package com.example.modoosugang_be.Repository;
+
+import com.example.modoosugang_be.Domain.Request;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RequestingRepository extends JpaRepository<Request, Long> {
+    List<Request> findAllByProfessor(String professor);
+}

--- a/src/main/java/com/example/modoosugang_be/Service/LectureService.java
+++ b/src/main/java/com/example/modoosugang_be/Service/LectureService.java
@@ -18,4 +18,9 @@ public class LectureService {
 
         return lectures;
     }
+
+    public Lecture callLecutureByUnivAndId(String univ, String id) {
+        return lectureRepository.findLectureByUnivAndID(univ, id);
+    }
+
 }

--- a/src/main/java/com/example/modoosugang_be/Service/LectureService.java
+++ b/src/main/java/com/example/modoosugang_be/Service/LectureService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,12 +16,26 @@ public class LectureService {
 
     public List<Lecture>callUnivLecture(String univ) {
         List<Lecture> lectures = lectureRepository.findLecture(univ);
-
         return lectures;
     }
 
     public Lecture callLecutureByUnivAndId(String univ, String id) {
         return lectureRepository.findLectureByUnivAndID(univ, id);
+    }
+
+    public List<Lecture> findLectureList(String semester) {
+        List<Lecture> logs = lectureRepository.findAllBySemester(semester);
+        return logs;
+    }
+
+    public Optional<Lecture> findRemain(Long code) {
+        return lectureRepository.findById(code);
+    }
+
+
+    public int setRemain(long code, int inputRemain) {
+        return lectureRepository.updateRemain(code, inputRemain);
+
     }
 
 }

--- a/src/main/java/com/example/modoosugang_be/Service/MailService.java
+++ b/src/main/java/com/example/modoosugang_be/Service/MailService.java
@@ -1,0 +1,30 @@
+package com.example.modoosugang_be.Service;
+
+import com.example.modoosugang_be.Domain.EmailMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendMail(EmailMessage emailMessage) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(emailMessage.getTo()); // 메일 수신자
+            mimeMessageHelper.setSubject(emailMessage.getSubject()); // 메일 제목
+            mimeMessageHelper.setText(emailMessage.getMessage(), false); // 메일 본문 내용, HTML 여부
+            javaMailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/example/modoosugang_be/Service/ProfessorService.java
+++ b/src/main/java/com/example/modoosugang_be/Service/ProfessorService.java
@@ -1,0 +1,19 @@
+package com.example.modoosugang_be.Service;
+
+import com.example.modoosugang_be.Domain.Professor;
+import com.example.modoosugang_be.Repository.ProfessorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfessorService {
+    private final ProfessorRepository professorRepository;
+
+    public List<Professor> callProfessorList(){
+        return professorRepository.findAll();
+    }
+}

--- a/src/main/java/com/example/modoosugang_be/Service/RegisterBasketService.java
+++ b/src/main/java/com/example/modoosugang_be/Service/RegisterBasketService.java
@@ -9,13 +9,10 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class RegisterLectureService {
+public class RegisterBasketService {
 
     private final RegisterLectureRepository registerLectureRepository;
 
-    public List<RegisterLecture> findRegisterLecture(String univ, String student) {
-        return registerLectureRepository.findAllByUnivAndStudent(univ, student);
-    }
 
     public RegisterLecture save(RegisterLecture regist) {
         return registerLectureRepository.save(regist);

--- a/src/main/java/com/example/modoosugang_be/Service/RegisterLectureService.java
+++ b/src/main/java/com/example/modoosugang_be/Service/RegisterLectureService.java
@@ -1,0 +1,19 @@
+package com.example.modoosugang_be.Service;
+
+import com.example.modoosugang_be.Domain.RegisterLecture;
+import com.example.modoosugang_be.Repository.RegisterLectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterLectureService {
+
+    private final RegisterLectureRepository registerLectureRepository;
+
+    public List<RegisterLecture> findRegisterLecture(String univ, String student) {
+        return registerLectureRepository.findAllByUnivAndStudent(univ, student);
+    }
+}

--- a/src/main/java/com/example/modoosugang_be/Service/RequestingService.java
+++ b/src/main/java/com/example/modoosugang_be/Service/RequestingService.java
@@ -1,0 +1,19 @@
+package com.example.modoosugang_be.Service;
+
+import com.example.modoosugang_be.Domain.Request;
+import com.example.modoosugang_be.Repository.RequestingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RequestingService {
+
+    private final RequestingRepository requestingRepository;
+
+    public List<Request> callRequestByProfessor(String professor) {
+        return requestingRepository.findAllByProfessor(professor);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,12 +21,3 @@ spring.jpa.hibernate.ddl-auto=update
 # JPA? ???? Hibernate? ????? ??? SQL? ???? ????.
 spring.jpa.properties.hibernate.format_sql=true
 
-# ---------------------------------------------------------
-spring.mail.host=smtp.naver.com
-spring.mail.port=465
-spring.mail.username=
-spring.mail.password=
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.smtp.starttls.required=true
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.ssl.enable=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,4 +21,12 @@ spring.jpa.hibernate.ddl-auto=update
 # JPA? ???? Hibernate? ????? ??? SQL? ???? ????.
 spring.jpa.properties.hibernate.format_sql=true
 
-spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+# ---------------------------------------------------------
+spring.mail.host=smtp.naver.com
+spring.mail.port=465
+spring.mail.username=
+spring.mail.password=
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.ssl.enable=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/modoosugang?useSSL=false&useUn
 spring.datasource.username=root
 
 # DB password
-spring.datasource.password=123123
+spring.datasource.password=12341234
 
 # true ??? JPA ??? ?? ??
 spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/modoosugang?useSSL=false&useUn
 spring.datasource.username=root
 
 # DB password
-spring.datasource.password=12341234
+spring.datasource.password=123123
 
 # true ??? JPA ??? ?? ??
 spring.jpa.show-sql=true


### PR DESCRIPTION
- 수강신청 페이지 구현 
    1. lecture 테이블의 데이터 테이블에 띄우기 (완료)
    2. 신청 버튼 클릭 후 lecture 테이블 잔여 차감하기 (완료)
    3. register_lecture 테이블에 신청 성공과목 저장 (완료)
    
    기타) 리액트 Table에서 신청 버튼누르면 해당 과목의 코드를 가져오는 부분 Pass
    
진행중 : 장바구니 신청 페이지 구현 

진행 예정 : [장바구니 신청] 및 [현재 신청 내역] 테이블 마무리, (장바구니 구현 후 진행)   ,  과목 추천 및 과목 필터링 기능

==================================================
세부 구현 내용은 ISSUE에 기록
